### PR TITLE
Use the signing key for openhab packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,9 +15,6 @@
 # * `manage_repo`
 #  Whether the openhab repo should be used. As of now this is the only
 #  option to install openHab with this module.
-#  WARNING: The openHAB packages are not signed yet, so we need to modify apt
-#           to allow the installation of unsigned packages. This *could* be a
-#           security risk.
 #
 # * `manage_java`
 #  Install java if necessary. This utilizes the puppetlabs-java module

--- a/manifests/install/v1.pp
+++ b/manifests/install/v1.pp
@@ -23,17 +23,11 @@ class openhab::install::v1 {
       /Ubuntu|Debian|Raspbian/: {
         include apt
 
-# Until now openHAB does not sign its packages.
-# Sorry that very bad hack.
-        apt::conf { 'AllowUnauthenticated':
-          ensure  => present,
-          content => 'APT::Get::AllowUnauthenticated yes;',
-        }
-
         apt::source { 'openhab':
           location => 'http://dl.bintray.com/openhab/apt-repo',
           release  => $::openhab::version,
           repos    => 'main',
+          key      => 'EDB7D0304E2FCAF629DF1163075721F6A224060A',
         }
       }
       default:  {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,7 +12,6 @@ describe 'openhab' do
 
   context 'with defaults on debian' do
     it { should contain_apt__source('openhab') }
-    it { should contain_apt__conf('AllowUnauthenticated') }
     it { should contain_package('openhab-runtime') }
     it { should contain_service('openhab') }
     it { should contain_file('/var/lib/openhab').with('ensure' => 'directory') }
@@ -27,7 +26,6 @@ describe 'openhab' do
     let(:params) { {:manage_repo => false } }
 
     it { should_not contain_apt__source('openhab') }
-    it { should_not contain_apt__conf('AllowUnauthenticated') }
     it { should contain_package('openhab-runtime') }
     it { should contain_service('openhab') }
     it { should contain_user('openhab').with('home' => '/var/lib/openhab') }

--- a/spec/classes/v2_spec.rb
+++ b/spec/classes/v2_spec.rb
@@ -13,7 +13,6 @@ describe 'openhab' do
 
   context 'with defaults on debian' do
     it { should_not contain_apt__source('openhab') }
-    it { should_not contain_apt__conf('AllowUnauthenticated') }
     it { should_not contain_package('openhab-runtime') }
     it { should contain_service('openhab') }
     it { should contain_user('openhab').with('home' => '/opt/openhab') }


### PR DESCRIPTION
As per https://github.com/openhab/openhab/wiki/Linux---OS-X#apt-get the repository is now signed.
